### PR TITLE
Adding data caching for intial queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+query_cache.RData

--- a/app.R
+++ b/app.R
@@ -62,6 +62,14 @@ chars <- c("All RPA Characteristics",".alpha.-Endosulfan ",".alpha.-Hexachlorocy
           "trans-1,2-Dichloroethylene ","Tribromomethane ","Tributlytin ","Tributyltin ","Trichloroethene (TCE) ",
           "Turbidity","Turbidity Field","Vinyl chloride ","Zinc ")
 
+# Check to see if saved cache of data exists. If it does not, or is greater than
+# 7 days old, query out stations and organizations and save the cache
+# 
+
+if(!file.exists("query_cache.RData") | 
+   difftime(Sys.Date() ,file.mtime("query_cache.RData") , units = c("days")) > 7){
+  
+
 #NPDES_AWQMS_Stations functions only pulls stations 
 station <- NPDES_AWQMS_Stations()
 station <- station$MLocID
@@ -70,6 +78,12 @@ station <- sort(station)
 organization <- AWQMS_Orgs()
 organization <- organization$OrganizationID
 organization <- sort(organization)
+
+save(station, organization, file = 'query_cache.RData')
+} else {
+  load("query_cache.RData")
+}
+
 
 HUC8_Names <- c('Alsea', 'Alvord Lake', 'Applegate', 'Beaver-South Fork',
                 'Brownlee Reservoir', 'Bully', 'Burnt', 'Chetco', 'Chief Joseph',


### PR DESCRIPTION
This will speed up the loading of the AWQMS shiny app. The first time it's run, the app will save the results of the NPDES_AWQMS_Stations() query and the AWQMS_Orgs() query in a file called query_cache.RData

On subsequent runs, the app will check to see if that file exists, and if it was modified within the last 7 days. If it was modified 7 or less days ago, the app will just reload the data and skip having to query out of awqms, If the file does not exist, or is older than 7 days, it will rerun the queries. 

Since the only queries are stations and organizations, you can probably adjust to a longer time period than 7 days (30?). Just change the number on line 70.